### PR TITLE
Fix one-off column naming issues

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -54,8 +54,8 @@ ALLOWED_NON_CID_SUBSTRINGS = ['num', 'state']
 # to occur again so we will fix them explicitly rather than trying to put together a generalized approach.
 ONE_OFF_COLUMN_RENAME_MAPPINGS = {
     "FlatConnect.module1_v1_JP": [
-        {"source": "D_122887481_TUBLIG_D_232595513", "target": "D_12288748_D_623218391", "description": "Fix Tubal Ligation Age CID"},
-        {"source": "D_122887481_TUBLIG_D_614366597", "target": "D_12288748_D_802622485", "description": "Fix Tubal Ligation Year CID"},
+        {"source": "D_122887481_TUBLIG_D_232595513", "target": "D_122887481_D_623218391", "description": "Fix Tubal Ligation Age CID"},
+        {"source": "D_122887481_TUBLIG_D_614366597", "target": "D_122887481_D_802622485", "description": "Fix Tubal Ligation Year CID"},
         {"source": "D_259089008_1_1_SIBCANC3O_D_230633094_1", "target": "D_259089008_D_206625031_1", "description": "Fix Sibling Cancer Age CID"},
         {"source": "D_259089008_1_1_SIBCANC3O_D_962468280_1", "target": "D_259089008_D_261863326_1", "description": "Fix Sibling Cancer Year CID"},
         {"source": "D_301414575_DEPRESS2_D_479548517", "target": "D_301414575_D_261863326", "description": "Fix Depression Year CID"},

--- a/core/constants.py
+++ b/core/constants.py
@@ -83,7 +83,7 @@ ONE_OFF_COLUMN_RENAME_MAPPINGS = {
         {"source": "D_907590067_4_4_SIBCANC3O_D_650332509_4", "target": "D_907590067_D_261863326_4", "description": "Fix Sibling Cancer Year CID"},
         {"source": "D_907590067_4_4_SIBCANC3D_D_932489634_4", "target": "D_907590067_D_206625031_4", "description": "Fix Sibling Breast Cancer Age CID"}
     ],
-    "FlatConnect.covid19Survey": [
+    "FlatConnect.covid19Survey_v1_JP": [
         {"source": "d_71558179_v2_1_1", "target": "d_715581797_1_v2", "description": ""},
         {"source": "d_71558179_v2_2_2", "target": "d_715581797_2_v2", "description": ""}, 
         {"source": "d_71558179_v2_3_3", "target": "d_715581797_3_v2", "description": ""}, 

--- a/core/constants.py
+++ b/core/constants.py
@@ -62,7 +62,7 @@ ONE_OFF_COLUMN_RENAME_MAPPINGS = {
         {"source": "D_301414575_DEPRESS2_D_591959654", "target": "D_301414575_D_206625031", "description": "Fix Depression Age CID"},
         {"source": "D_301679110_DM2_D_166195719", "target": "D_301679110_D_261863326", "description": "Fix Diabetes Year CID"},
         {"source": "D_301679110_DM2_D_861769692", "target": "D_301679110_D_206625031", "description": "Fix Diabetes Age CID"},
-        {"source": "D_355472178_BREASTDIS_D_138780721", "target": "D_619481x697_D_261863326", "description": "Fix Breast Disease Year CID"},
+        {"source": "D_355472178_BREASTDIS_D_138780721", "target": "D_619481697_D_261863326", "description": "Fix Breast Disease Year CID"},
         {"source": "D_355472178_BREASTDIS_D_162512268", "target": "D_619481697_D_206625031", "description": "Fix Breast Disease Age CID"},
         {"source": "D_367884741_TONSILS_D_300754548", "target": "D_367884741_D_623218391", "description": "Fix Tonsillectomy Age CID"},
         {"source": "D_367884741_TONSILS_D_714712574", "target": "D_367884741_D_802622485", "description": "Fix Tonsillectomy Year CID"},

--- a/core/constants.py
+++ b/core/constants.py
@@ -45,3 +45,54 @@ EXCLUDED_NON_CID_SUBSTRINGS = list(
 # Allowable non-concept id substrings
 ALLOWED_NON_CID_SUBSTRINGS = ['num', 'state']
 
+# ------------------------------------------------------------------------------
+# Define one-off column renames that cannot be handled by generalized columns
+# ------------------------------------------------------------------------------
+
+# Table-specific variable name corrections. 
+# Variations on this theme of misnamed variables are not expected 
+# to occur again so we will fix them explicitly rather than trying to put together a generalized approach.
+ONE_OFF_COLUMN_RENAME_MAPPINGS = {
+    "FlatConnect.module1_v1_JP": [
+        {"source": "D_122887481_TUBLIG_D_232595513", "target": "D_12288748_D_623218391", "description": "Fix Tubal Ligation Age CID"},
+        {"source": "D_122887481_TUBLIG_D_614366597", "target": "D_12288748_D_802622485", "description": "Fix Tubal Ligation Year CID"},
+        {"source": "D_259089008_1_1_SIBCANC3O_D_230633094_1", "target": "D_259089008_D_206625031_1", "description": "Fix Sibling Cancer Age CID"},
+        {"source": "D_259089008_1_1_SIBCANC3O_D_962468280_1", "target": "D_259089008_D_261863326_1", "description": "Fix Sibling Cancer Year CID"},
+        {"source": "D_301414575_DEPRESS2_D_479548517", "target": "D_301414575_D_261863326", "description": "Fix Depression Year CID"},
+        {"source": "D_301414575_DEPRESS2_D_591959654", "target": "D_301414575_D_206625031", "description": "Fix Depression Age CID"},
+        {"source": "D_301679110_DM2_D_166195719", "target": "D_301679110_D_261863326", "description": "Fix Diabetes Year CID"},
+        {"source": "D_301679110_DM2_D_861769692", "target": "D_301679110_D_206625031", "description": "Fix Diabetes Age CID"},
+        {"source": "D_355472178_BREASTDIS_D_138780721", "target": "D_619481x697_D_261863326", "description": "Fix Breast Disease Year CID"},
+        {"source": "D_355472178_BREASTDIS_D_162512268", "target": "D_619481697_D_206625031", "description": "Fix Breast Disease Age CID"},
+        {"source": "D_367884741_TONSILS_D_300754548", "target": "D_367884741_D_623218391", "description": "Fix Tonsillectomy Age CID"},
+        {"source": "D_367884741_TONSILS_D_714712574", "target": "D_367884741_D_802622485", "description": "Fix Tonsillectomy Year CID"},
+        {"source": "D_370198527_DADCANC3K_D_260972338", "target": "D_370198527_D_206625031", "description": "Fix Father's Lung Cancer Age CID"},
+        {"source": "D_370198527_DADCANC3K_D_331562964", "target": "D_370198527_D_261863326", "description": "Fix Father's Lung Cancer Year CID"},
+        {"source": "D_402548942_MOMCANC3D_D_388289687", "target": "D_402548942_D_206625031", "description": "Fix Mother's Breast Cancer Age CID"},
+        {"source": "D_402548942_MOMCANC3D_D_734800333", "target": "D_402548942_D_261863326", "description": "Fix Mother's Breast Cancer Year CID"},
+        {"source": "D_460062034_BLOODCLOT_D_497018554", "target": "D_460062034_D_206625031", "description": "Fix Blood Clot Age CID"},
+        {"source": "D_460062034_BLOODCLOT_D_694594047", "target": "D_460062034_D_261863326", "description": "Fix Blood Clot Year CID"},
+        {"source": "D_550075233_APPEND_D_727704681", "target": "D_550075233_D_802622485", "description": "Fix Appendectomy Year CID"},
+        {"source": "D_550075233_APPEND_D_919193251", "target": "D_550075233_D_623218391", "description": "Fix Appendectomy Age CID"},
+        {"source": "D_836890480_CHOL_D_470282814", "target": "D_836890480_D_261863326", "description": "Fix High Cholesterol Year CID"},
+        {"source": "D_836890480_CHOL_D_637556277", "target": "D_836890480_D_206625031", "description": "Fix High Cholesterol Age CID"},
+        {"source": "D_846786840_UF_D_351965599", "target": "D_846786840_D_261863326", "description": "Fix Uterine Fibroid Year CID"},
+        {"source": "D_846786840_UF_D_895115511", "target": "D_846786840_D_206625031", "description": "Fix Uterine Fibroid Age CID"},
+        {"source": "D_884793537_HTN_D_367670682", "target": "D_884793537_D_206625031", "description": "Fix Hypertension Age CID"},
+        {"source": "D_884793537_HTN_D_608469482", "target": "D_884793537_D_261863326", "description": "Fix Hypertension Year CID"},
+        {"source": "D_907590067_4_4_SIBCANC3O_D_650332509_4", "target": "D_907590067_D_261863326_4", "description": "Fix Sibling Cancer Year CID"},
+        {"source": "D_907590067_4_4_SIBCANC3D_D_932489634_4", "target": "D_907590067_D_206625031_4", "description": "Fix Sibling Breast Cancer Age CID"}
+    ],
+    "FlatConnect.covid19Survey": [
+        {"source": "d_71558179_v2_1_1", "target": "d_715581797_1_v2", "description": ""},
+        {"source": "d_71558179_v2_2_2", "target": "d_715581797_2_v2", "description": ""}, 
+        {"source": "d_71558179_v2_3_3", "target": "d_715581797_3_v2", "description": ""}, 
+        {"source": "d_71558179_v2_4_4", "target": "d_715581797_4_v2", "description": ""}, 
+        {"source": "d_71558179_v2_5_5", "target": "d_715581797_5_v2", "description": ""}, 
+        {"source": "d_71558179_v2_6_6", "target": "d_715581797_6_v2", "description": ""}, 
+        {"source": "d_71558179_v2_7_7", "target": "d_715581797_7_v2", "description": ""}, 
+        {"source": "d_71558179_v2_8_8", "target": "d_715581797_8_v2", "description": ""}, 
+        {"source": "d_71558179_v2_9_9", "target": "d_715581797_9_v2", "description": ""}, 
+        {"source": "d_71558179_v2_10_10", "target": "d_715581797_10_v2", "description": ""}
+    ]
+}

--- a/core/endpoints.py
+++ b/core/endpoints.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from flask import Flask, jsonify, request  # type: ignore
 
-from core import query_composition, constants, utils, request_helpers
+from core import constants, transformations, utils, request_helpers
 
 app = Flask(__name__)
 
@@ -24,8 +24,8 @@ def fix_loop_variables():
     source, destination = request_helpers.extract_source_and_destination(mapping)
     
     try:
-        utils.logger.info(f"fix_loop_variables endpoint called. Generating {source} from {destination}.")
-        status = query_composition.compose_coalesce_loop_variable_query(source, destination)
+        utils.logger.info(f"fix_loop_variables endpoint called. Generating {destination} from {source}.")
+        status = transformations.process_columns(source, destination)  # Updated function call
         return jsonify({
             'status': status,
             'timestamp': datetime.utcnow().isoformat(),
@@ -42,7 +42,7 @@ def merge_table_versions():
     
     try:
         utils.logger.info(f"merge_table_versions endpoint called. Merging {source} to generate {destination}.")
-        status = query_composition.create_or_replace_table_with_outer_join(source, destination)
+        status = transformations.merge_table_versions(source, destination)
         return jsonify({
             'status': status,
             'timestamp': datetime.utcnow().isoformat(),

--- a/core/transformations.py
+++ b/core/transformations.py
@@ -257,10 +257,11 @@ def apply_one_off_column_renames(source_table: str, destination_table: str) -> t
             utils.logger.info(f"Coalescing: {coalesce_expr}")
     
     # Create the SQL for the destination table
+    separator = ',\n        '
     sql = f"""
     CREATE OR REPLACE TABLE `{destination_table}` AS
     SELECT
-        {',\\n        '.join(select_parts)}
+        {separator.join(select_parts)}
     FROM `{source_table}`
     """
     

--- a/core/transformations.py
+++ b/core/transformations.py
@@ -260,7 +260,7 @@ def apply_one_off_column_renames(source_table: str, destination_table: str) -> t
     sql = f"""
     CREATE OR REPLACE TABLE `{destination_table}` AS
     SELECT
-        {',\n        '.join(select_parts)}
+        {',\\n        '.join(select_parts)}
     FROM `{source_table}`
     """
     

--- a/core/transformations.py
+++ b/core/transformations.py
@@ -110,7 +110,7 @@ def merge_table_versions(source_tables: list[str], destination_table: str) -> di
         gcs_path = f"{constants.OUTPUT_SQL_PATH}{destination_table}.sql"
         utils.save_sql_string(sql=final_query, path=gcs_path, storage_client=gcs_client)
     except Exception as e:
-        utils.logger.exception("Error executing saving query {gcs_path}.")
+        utils.logger.exception(f"Error executing saving query {gcs_path}.")
         raise e
 
     # Submit query job to BQ
@@ -399,7 +399,7 @@ def process_loop_and_versioned_variables(source_table: str, destination_table: s
         gcs_path = f"{constants.OUTPUT_SQL_PATH}{destination_table}.sql"
         utils.save_sql_string(sql=final_query, path=gcs_path, storage_client=gcs_client)
     except Exception as e:
-        utils.logger.exception("Error executing saving query {gcs_path}.")
+        utils.logger.exception(f"Error executing saving query {gcs_path}.")
         raise e
 
     # Submit query job to BQ

--- a/core/transformations.py
+++ b/core/transformations.py
@@ -473,7 +473,7 @@ def process_columns(source_table: str, destination_table: str) -> dict:
     # Create intermediate table name with timestamp to avoid collisions
     from datetime import datetime
     project, dataset, table = utils.parse_fq_table(source_table)
-    intermediate_table = f"{project}.{dataset}.intermediate_{table}_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}"
+    intermediate_table = f"{project}.{dataset}.intermediate_{table}"
     
     try:
         # Step 1: Apply one-off renames (if applicable)


### PR DESCRIPTION
- Renames columns with non Concept ID column names (e.g., "TUBLIG") with the appropriate concept IDs
- Rename columns with 8-digit concept IDs to appropriate 9-digit concept IDs, e.g., `d_71558179*` --> `d_715581797*`
- Added ONE_OFF_COLUMN_RENAME_MAPPINGS to constants module
- rename query_composition.py to transformations.py
- Add `apply_one_off_column_renames()` to transformations.py
- Renamed `coalesce_and_rename_loop_variables` to `process_loop_and_versioned_variables`

Closes: [#17](https://github.com/Analyticsphere/pr2-documentation/issues/17)
Closes: [#21](https://github.com/Analyticsphere/pr2-documentation/issues/21)